### PR TITLE
feat: incremental appointment sync

### DIFF
--- a/auth-solutions.md
+++ b/auth-solutions.md
@@ -1,0 +1,652 @@
+# Authentication & Session Handling — Solution Options
+
+## Current State
+
+### How auth works today
+
+```
+┌─────────┐    x-findbolig-cookies    ┌──────────────┐    Cookie header    ┌───────────────┐
+│  Client  │ ────────────────────────► │ Hono Backend │ ──────────────────► │ findbolig.nu  │
+│ (Vue 3)  │ ◄──────────────────────── │ (Cloud Run)  │ ◄────────────────── │  (Sitecore)   │
+└─────────┘    UserData + cookies[]    └──────────────┘    Set-Cookie       └───────────────┘
+```
+
+1. **Login**: Client sends email/password → Backend POSTs to `findbolig.nu/api/authentication/login` → receives `Set-Cookie` headers (`.ASPXAUTH`, `__Secure-SID`) → returns them to the client as a string array.
+2. **Authenticated requests**: Client sends findbolig cookies via `x-findbolig-cookies` header → Backend forwards them as a `Cookie` header to findbolig.nu.
+3. **Session keep-alive**: Client-side `setInterval` every 5 minutes calls `GET /api/auth/refresh` → Backend hits `findbolig.nu/api/users/me` → returns updated cookies if any.
+4. **Storage**: Pinia store with `pinia-plugin-persistedstate` saves cookies, email, name, and optionally password to `localStorage`.
+
+### What `ensureSession()` already solves
+
+The `ui-polish-and-fixes` branch added `validateSession()` and `ensureSession()` to `useAuth.ts`:
+
+```typescript
+async function ensureSession(): Promise<boolean> {
+  // 1. Try existing session first
+  if (cookies.value) {
+    const valid = await validateSession();
+    if (valid) return true;
+  }
+  // 2. Session invalid — try auto-relogin if credentials are remembered
+  if (rememberPassword.value && email.value && password.value) {
+    const ok = await login(email.value, password.value);
+    return !!ok;
+  }
+  // 3. No stored credentials — user must log in manually
+  return false;
+}
+```
+
+This handles the "session expired while tab was open" case — if the user opted into "Remember Password", the app auto-re-authenticates without prompting.
+
+### Remaining pain points
+
+| Problem | Impact |
+|---------|--------|
+| **Password stored as plaintext in localStorage** | Any XSS vulnerability or browser extension can read it. Security-conscious users may not trust this. |
+| **Client holds findbolig session cookies** | Cookies are visible in DevTools, localStorage, and any JS running on the page. |
+| **Tab closed = session lost** | findbolig cookies expire after ~20 minutes. User reopens tab → must re-login (or auto-relogin with stored password). |
+| **No server-side resilience** | Backend is fully stateless — if the client loses cookies, the session is gone. No way to recover without re-authenticating. |
+| **Keep-alive only runs while tab is open** | Background tabs get throttled by browsers. If the user leaves for 30+ minutes, the session will expire. |
+
+---
+
+## Option 1: Client-Side Improvements Only
+
+**Philosophy**: Enhance what's already there. No backend changes. Stay on Cloud Run as-is.
+
+### Changes
+
+#### 1a. Refresh on tab focus (Page Visibility API)
+
+```typescript
+// useAuth.ts — add inside the store setup
+document.addEventListener("visibilitychange", async () => {
+  if (document.visibilityState === "visible" && isAuthenticated.value) {
+    const valid = await validateSession();
+    if (!valid) await ensureSession();
+  }
+});
+```
+
+When the user switches back to the tab, immediately check if the session is still alive. If not, try auto-relogin.
+
+#### 1b. Use `ensureSession()` as a guard before every API call
+
+```typescript
+// client/src/data/appointmentsSource.ts
+export async function fetchAppointments(auth: ReturnType<typeof useAuth>) {
+  const sessionOk = await auth.ensureSession();
+  if (!sessionOk) throw new Error("Session expired — please log in again.");
+
+  const res = await fetch(`${config.backendDomain}/api/appointments/upcoming`, {
+    headers: { "x-findbolig-cookies": auth.cookies },
+  });
+  // ...
+}
+```
+
+#### 1c. Reduce keep-alive interval
+
+Change from 5 minutes to 3 minutes (Sitecore default timeout is ~20 min, so 3 min gives plenty of margin with sliding expiration):
+
+```typescript
+keepAliveTimer = window.setInterval(async () => {
+  // ...
+}, 3 * 60 * 1000); // 3 minutes
+```
+
+### Pros
+
+- **Minimal effort** — a few hours of work, no infrastructure changes.
+- **No new dependencies** — no database, no encryption libraries.
+- **Cloud Run stays as-is** — no cost increase, no new services.
+- **`ensureSession()` already does the heavy lifting** — just needs to be wired in.
+
+### Cons
+
+- **Password is still plaintext in localStorage** — the fundamental security concern remains. Any XSS or malicious extension can steal it.
+- **Client is still the session authority** — the browser is the only place cookies and credentials live.
+- **Keep-alive is unreliable** — browsers throttle `setInterval` in background tabs (Chrome: once per minute max). A 20-minute findbolig timeout can still be missed.
+- **No transparency story** — hard to tell users "your credentials are safe" when they're in plaintext localStorage.
+
+### Best for
+
+Quick improvement while deciding on a more robust solution. Good as a **Phase 1** before implementing Option 2 or 3.
+
+---
+
+## Option 2: Server-Side Session Store + Auto Re-Auth
+
+**Philosophy**: Move session state and credentials to the server. Client gets a session token and never touches findbolig cookies or credentials directly. Stay on Cloud Run.
+
+### Architecture
+
+```
+┌─────────┐   session token (JWT)   ┌──────────────┐    Cookie header    ┌───────────────┐
+│  Client  │ ──────────────────────► │ Hono Backend │ ──────────────────► │ findbolig.nu  │
+│ (Vue 3)  │ ◄────────────────────── │ (Cloud Run)  │ ◄────────────────── │  (Sitecore)   │
+└─────────┘   JSON responses only    └──────┬───────┘    Set-Cookie       └───────────────┘
+                                            │
+                                     ┌──────▼───────┐
+                                     │  Firestore   │
+                                     │  (or Redis)  │
+                                     │              │
+                                     │ • fb cookies  │
+                                     │ • encrypted   │
+                                     │   credentials │
+                                     │ • lastActive  │
+                                     └──────────────┘
+```
+
+### How it works
+
+1. **Login**: Client sends email/password → Server authenticates with findbolig.nu → Server stores findbolig cookies + AES-encrypted credentials in Firestore → Server returns a signed JWT (or sets an HttpOnly cookie) to the client.
+2. **Authenticated requests**: Client sends JWT → Server looks up findbolig cookies from Firestore → forwards to findbolig.nu. Client never sees findbolig cookies.
+3. **401 from findbolig**: Server catches it → decrypts stored credentials → re-authenticates with findbolig.nu → updates stored cookies → retries the original request. Transparent to client.
+4. **Logout**: Server deletes the session from Firestore, clears findbolig cookies.
+
+### Code examples
+
+#### Server: Session store abstraction
+
+```typescript
+// server/src/lib/session-store.ts
+import { Firestore } from "@google-cloud/firestore";
+import { encrypt, decrypt } from "./crypto";
+
+const db = new Firestore();
+const sessions = db.collection("sessions");
+
+interface StoredSession {
+  findboligCookies: string;
+  encryptedEmail: string;
+  encryptedPassword: string;
+  lastActive: number;
+}
+
+export async function createSession(sessionId: string, data: {
+  cookies: string;
+  email: string;
+  password: string;
+}) {
+  await sessions.doc(sessionId).set({
+    findboligCookies: data.cookies,
+    encryptedEmail: encrypt(data.email),
+    encryptedPassword: encrypt(data.password),
+    lastActive: Date.now(),
+  });
+}
+
+export async function getSession(sessionId: string): Promise<StoredSession | null> {
+  const doc = await sessions.doc(sessionId).get();
+  return doc.exists ? (doc.data() as StoredSession) : null;
+}
+
+export async function updateCookies(sessionId: string, cookies: string) {
+  await sessions.doc(sessionId).update({
+    findboligCookies: cookies,
+    lastActive: Date.now(),
+  });
+}
+
+export async function deleteSession(sessionId: string) {
+  await sessions.doc(sessionId).delete();
+}
+```
+
+#### Server: Login route with session creation
+
+```typescript
+// server/src/index.ts — modified login route
+import { sign } from "hono/jwt";
+import { createSession } from "~/lib/session-store";
+
+auth.post("/login", async (c) => {
+  const { email, password } = await c.req.json();
+  if (!email || !password) {
+    return c.json({ error: "Email and password are required" }, 400);
+  }
+
+  const result = await findboligService.login(email, password);
+  if (!result?.cookies) {
+    return c.json({ error: "Login failed" }, 401);
+  }
+
+  const sessionId = crypto.randomUUID();
+  const cookieString = parseCookies(result.cookies);
+
+  await createSession(sessionId, {
+    cookies: cookieString,
+    email,
+    password,
+  });
+
+  const token = await sign(
+    { sub: sessionId, exp: Math.floor(Date.now() / 1000) + 7 * 24 * 3600 },
+    process.env.JWT_SECRET!,
+  );
+
+  // Return JWT + user info (no cookies exposed to client)
+  return c.json({ token, fullName: result.fullName, email: result.email });
+});
+```
+
+#### Server: Auto re-auth middleware
+
+```typescript
+// server/src/lib/auth-middleware.ts
+import { getSession, updateCookies } from "./session-store";
+import { decrypt } from "./crypto";
+import * as findboligService from "~/findbolig-service";
+
+export async function getValidCookies(sessionId: string): Promise<string | null> {
+  const session = await getSession(sessionId);
+  if (!session) return null;
+
+  // Try existing cookies first
+  const testRes = await fetch("https://findbolig.nu/api/users/me", {
+    headers: { Cookie: session.findboligCookies },
+  });
+
+  if (testRes.ok) {
+    return session.findboligCookies;
+  }
+
+  // Cookies expired — re-authenticate
+  const email = decrypt(session.encryptedEmail);
+  const password = decrypt(session.encryptedPassword);
+  const freshLogin = await findboligService.login(email, password);
+
+  if (!freshLogin?.cookies) return null;
+
+  const newCookies = parseCookies(freshLogin.cookies);
+  await updateCookies(sessionId, newCookies);
+  return newCookies;
+}
+```
+
+#### Client: Simplified auth store
+
+```typescript
+// client/src/composables/useAuth.ts — simplified
+const token = ref("");   // JWT only, no findbolig cookies
+const name = ref("");
+
+async function login(userEmail: string, userPassword: string) {
+  const res = await fetch(`${config.backendDomain}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: userEmail, password: userPassword }),
+  });
+
+  if (!res.ok) return false;
+  const data = await res.json();
+  token.value = data.token;
+  name.value = data.fullName;
+  isAuthenticated.value = true;
+  return true;
+}
+
+// All API calls use the JWT, no cookies involved
+async function fetchWithAuth(url: string, options: RequestInit = {}) {
+  return fetch(url, {
+    ...options,
+    headers: {
+      ...options.headers,
+      Authorization: `Bearer ${token.value}`,
+    },
+  });
+}
+```
+
+### Pros
+
+- **Password never stored on client** — client only holds a JWT. No plaintext credentials in localStorage.
+- **Transparent re-auth** — session never expires from the user's perspective. Server handles it silently.
+- **Cloud Run compatible** — Firestore is serverless and scales with Cloud Run. No infrastructure changes needed.
+- **Good transparency story** — "Your credentials are encrypted on our server using AES-256 and only used to maintain your findbolig.nu session. They are deleted when you log out."
+- **Session survives tab close** — JWT is long-lived (e.g., 7 days). findbolig session is refreshed server-side when needed.
+
+### Cons
+
+- **Medium complexity** — need Firestore setup, encryption, JWT signing, new middleware.
+- **Credentials still stored somewhere** — even encrypted, storing user passwords is a responsibility. A compromised encryption key = all credentials exposed.
+- **Added latency** — Firestore lookup on every request (~10-50ms). Mitigated with Cloud Run in same region.
+- **Cost** — Firestore has a free tier (1 GiB storage, 50k reads/day) which is likely sufficient. Redis Memorystore starts at ~$30/month.
+- **Encryption key management** — need to manage `JWT_SECRET` and `ENCRYPTION_KEY` via Secret Manager or env vars.
+
+### Best for
+
+**Recommended if staying on Cloud Run.** Good balance of security, UX, and complexity. Firestore's free tier keeps costs near zero.
+
+---
+
+## Option 3: VPS with In-Memory Session Manager
+
+**Philosophy**: Move to a long-lived server process where sessions live in memory. Server proactively keeps sessions alive with background timers.
+
+### Architecture
+
+```
+┌─────────┐    session token     ┌───────────────────┐    Cookie header    ┌───────────────┐
+│  Client  │ ──────────────────► │  Hono on VPS      │ ──────────────────► │ findbolig.nu  │
+│ (Vue 3)  │ ◄────────────────── │  (Fly.io/Railway)  │ ◄────────────────── │  (Sitecore)   │
+└─────────┘                      │                   │                     └───────────────┘
+                                 │ In-memory Map:    │
+                                 │ sessionId → {     │
+                                 │   cookies,        │
+                                 │   credentials,    │
+                                 │   keepAliveTimer  │
+                                 │ }                 │
+                                 └───────────────────┘
+```
+
+### How it works
+
+1. **Login**: Same as Option 2, but session is stored in an in-memory `Map` instead of Firestore.
+2. **Background keep-alive**: On login, server starts a `setInterval` per user that pings `findbolig.nu/api/users/me` every 10 minutes. This keeps the Sitecore session alive even when the user's tab is closed.
+3. **Auto re-auth**: If the keep-alive gets a 401, server re-authenticates with stored credentials automatically.
+4. **Session cleanup**: Sessions expire after configurable inactivity (e.g., 24 hours without any client request). Timer is cleared on cleanup.
+
+### Code examples
+
+#### Server: In-memory session manager
+
+```typescript
+// server/src/lib/session-manager.ts
+import * as findboligService from "~/findbolig-service";
+
+interface Session {
+  findboligCookies: string;
+  email: string;
+  password: string;
+  lastClientActivity: number;
+  keepAliveTimer: ReturnType<typeof setInterval>;
+}
+
+const sessions = new Map<string, Session>();
+
+const KEEP_ALIVE_INTERVAL = 10 * 60 * 1000;  // 10 minutes
+const SESSION_TTL = 24 * 60 * 60 * 1000;     // 24 hours
+
+export function createSession(sessionId: string, data: {
+  cookies: string;
+  email: string;
+  password: string;
+}): void {
+  // Start background keep-alive for this session
+  const timer = setInterval(() => keepAlive(sessionId), KEEP_ALIVE_INTERVAL);
+
+  sessions.set(sessionId, {
+    findboligCookies: data.cookies,
+    email: data.email,
+    password: data.password,
+    lastClientActivity: Date.now(),
+    keepAliveTimer: timer,
+  });
+}
+
+async function keepAlive(sessionId: string): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+
+  // Clean up stale sessions
+  if (Date.now() - session.lastClientActivity > SESSION_TTL) {
+    destroySession(sessionId);
+    return;
+  }
+
+  // Ping findbolig to keep session alive
+  const res = await fetch("https://findbolig.nu/api/users/me", {
+    headers: { Cookie: session.findboligCookies },
+  });
+
+  if (res.ok) {
+    // Update cookies if new Set-Cookie headers
+    const newCookies = res.headers.getSetCookie();
+    if (newCookies.length > 0) {
+      session.findboligCookies = parseCookies(newCookies);
+    }
+    return;
+  }
+
+  // Session expired — re-authenticate
+  const freshLogin = await findboligService.login(session.email, session.password);
+  if (freshLogin?.cookies) {
+    session.findboligCookies = parseCookies(freshLogin.cookies);
+  } else {
+    destroySession(sessionId);
+  }
+}
+
+export function getSession(sessionId: string): Session | undefined {
+  const session = sessions.get(sessionId);
+  if (session) session.lastClientActivity = Date.now();
+  return session;
+}
+
+export function destroySession(sessionId: string): void {
+  const session = sessions.get(sessionId);
+  if (session) {
+    clearInterval(session.keepAliveTimer);
+    sessions.delete(sessionId);
+  }
+}
+
+// Cleanup on shutdown
+process.on("SIGTERM", () => {
+  for (const [id] of sessions) destroySession(id);
+});
+```
+
+#### Example VPS hosting (Fly.io)
+
+```toml
+# fly.toml
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 3000
+  auto_stop_machines = false   # Keep the machine running (no scale-to-zero)
+  min_machines_running = 1
+
+[env]
+  NODE_ENV = "production"
+```
+
+### Pros
+
+- **Simplest server-side solution** — no external database, no encryption libraries, just a `Map`.
+- **Proactive keep-alive** — server pings findbolig in the background. Sessions rarely expire.
+- **Low latency** — everything in-memory, no Firestore round-trips.
+- **Cheap** — Fly.io shared-cpu-1x is ~$3/month. Railway/Render have free tiers for small apps.
+- **Good enough for a small user base** — if you have <100 concurrent users, this handles it easily.
+
+### Cons
+
+- **Sessions lost on restart/deploy** — all users get logged out when you push a new version. Can be mitigated with graceful shutdown + fast re-auth, but annoying.
+- **Single point of failure** — one server instance. If it crashes, all sessions are gone.
+- **Doesn't scale horizontally** — multiple instances can't share in-memory sessions. Sticky sessions or a shared store would be needed.
+- **Credentials in plaintext in memory** — if the process is compromised, all credentials are exposed. (Encryption doesn't fully help since the key is also in memory.)
+- **No auto-scaling** — you're paying for the VPS even when no one is using it (though the cost is trivial).
+
+### Best for
+
+Small-scale app with a handful of users where simplicity is more valuable than resilience. **Good for a side project that doesn't need 99.9% uptime.**
+
+---
+
+## Option 4: Full Own-Auth Layer (JWT + Decoupled findbolig Session)
+
+**Philosophy**: fetchBolig.js becomes its own platform with proper user accounts. findbolig.nu is treated as an external integration that users link to their account.
+
+### Architecture
+
+```
+┌─────────┐   own JWT / session   ┌──────────────────────┐   Cookie hdr   ┌───────────────┐
+│  Client  │ ───────────────────► │  Hono Backend        │ ─────────────► │ findbolig.nu  │
+│ (Vue 3)  │ ◄─────────────────── │                      │ ◄───────────── │               │
+└─────────┘                       │  • Own user DB       │                └───────────────┘
+                                  │  • bcrypt passwords  │
+                                  │  • Session manager   │
+                                  │  • findbolig linker  │
+                                  └──────────┬───────────┘
+                                             │
+                                      ┌──────▼──────┐
+                                      │  Database   │
+                                      │ (SQLite /   │
+                                      │  Postgres)  │
+                                      │             │
+                                      │ users table │
+                                      │ linked_accs │
+                                      └─────────────┘
+```
+
+### How it works
+
+1. **Sign up**: User creates a fetchBolig.js account (email + password). Password is hashed with bcrypt and stored in the database.
+2. **Link findbolig account**: After signing in, user enters their findbolig.nu credentials in a "Link Account" flow. Server validates them against findbolig.nu, then stores them encrypted in the database.
+3. **Normal usage**: Client authenticates with fetchBolig.js JWT only. Server manages findbolig session entirely — client has zero awareness of findbolig auth.
+4. **Session management**: Server maintains findbolig sessions (keep-alive + auto re-auth) as in Option 2 or 3.
+
+### Code examples
+
+#### Database schema (SQLite with Drizzle ORM)
+
+```typescript
+// server/src/db/schema.ts
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("users", {
+  id: text("id").primaryKey(),            // UUID
+  email: text("email").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+  name: text("name"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+});
+
+export const linkedAccounts = sqliteTable("linked_accounts", {
+  id: text("id").primaryKey(),
+  userId: text("user_id").notNull().references(() => users.id),
+  provider: text("provider").notNull(),   // "findbolig"
+  encryptedEmail: text("encrypted_email").notNull(),
+  encryptedPassword: text("encrypted_password").notNull(),
+  lastSessionRefresh: integer("last_session_refresh", { mode: "timestamp" }),
+});
+```
+
+#### Server: Auth routes
+
+```typescript
+// server/src/routes/auth.ts
+import { Hono } from "hono";
+import bcrypt from "bcrypt";
+import { sign, verify } from "hono/jwt";
+import { db } from "~/db";
+import { users } from "~/db/schema";
+
+const auth = new Hono();
+
+auth.post("/register", async (c) => {
+  const { email, password, name } = await c.req.json();
+  const passwordHash = await bcrypt.hash(password, 12);
+  const id = crypto.randomUUID();
+
+  await db.insert(users).values({ id, email, passwordHash, name, createdAt: new Date() });
+
+  const token = await sign({ sub: id }, process.env.JWT_SECRET!);
+  return c.json({ token, name, email });
+});
+
+auth.post("/login", async (c) => {
+  const { email, password } = await c.req.json();
+  const user = await db.select().from(users).where(eq(users.email, email)).get();
+
+  if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
+    return c.json({ error: "Invalid credentials" }, 401);
+  }
+
+  const token = await sign({ sub: user.id }, process.env.JWT_SECRET!);
+  return c.json({ token, name: user.name, email: user.email });
+});
+```
+
+#### Server: Link findbolig account
+
+```typescript
+// server/src/routes/integrations.ts
+auth.post("/link-findbolig", async (c) => {
+  const userId = c.get("userId"); // from JWT middleware
+  const { email, password } = await c.req.json();
+
+  // Validate credentials against findbolig.nu
+  const result = await findboligService.login(email, password);
+  if (!result) {
+    return c.json({ error: "findbolig.nu login failed — check your credentials" }, 400);
+  }
+
+  // Store encrypted credentials
+  await db.insert(linkedAccounts).values({
+    id: crypto.randomUUID(),
+    userId,
+    provider: "findbolig",
+    encryptedEmail: encrypt(email),
+    encryptedPassword: encrypt(password),
+  });
+
+  return c.json({ ok: true, message: "findbolig.nu account linked" });
+});
+```
+
+### Pros
+
+- **Best security** — user's fetchBolig.js password is bcrypt-hashed. findbolig credentials are encrypted and isolated. Client never handles any sensitive tokens.
+- **Best transparency** — clear separation: "Your fetchBolig.js password is hashed. Your findbolig.nu credentials are encrypted and only used to sync your data. You can unlink at any time."
+- **Session is permanent** — user stays logged into fetchBolig.js for days/weeks (long-lived JWT). findbolig session is fully server-managed.
+- **Future-proof** — enables features like: multiple housing platform integrations, user preferences, notification settings, sharing between users.
+- **Can run anywhere** — Cloud Run + Cloud SQL, or VPS + SQLite.
+
+### Cons
+
+- **Highest complexity** — user database, registration flow, password hashing, encryption, DB migrations, account linking UI.
+- **Two sets of credentials** — users create a new account AND enter their findbolig credentials. Adds friction.
+- **Ongoing DB maintenance** — migrations, backups, security updates.
+- **Overkill for current scale** — if there are only a few users, this is significant overhead.
+- **Legal considerations** — storing user data may require GDPR compliance (privacy policy, data deletion, etc.).
+
+### Best for
+
+**When fetchBolig.js becomes a real product** with multiple users, potential for multiple integrations, and a need for a professional auth story. Not recommended for the current stage unless you're planning to grow significantly.
+
+---
+
+## Comparison
+
+| Criteria | Option 1: Client-Side | Option 2: Server + Firestore | Option 3: VPS In-Memory | Option 4: Own Auth |
+|---|---|---|---|---|
+| **Complexity** | Low | Medium | Medium | High |
+| **Implementation time** | Hours | 1-2 days | 1-2 days | 3-5 days |
+| **Security** | ⚠️ Plaintext in localStorage | ✅ Encrypted server-side | ✅ Server memory only | ✅✅ Hashed + encrypted |
+| **Transparency** | ⚠️ Hard to justify | ✅ Clear story | ✅ Clear story | ✅✅ Industry standard |
+| **UX** | OK (occasional re-logins) | Good (seamless) | Good (proactive) | Best (persistent) |
+| **Cloud Run compatible** | ✅ | ✅ (with Firestore) | ❌ (needs VPS) | ✅ (with Cloud SQL) |
+| **Survives tab close** | ❌ (unless re-login) | ✅ | ✅ | ✅ |
+| **Survives server restart** | N/A | ✅ | ❌ | ✅ |
+| **Scales horizontally** | N/A | ✅ | ❌ | ✅ |
+| **Monthly cost** | $0 | ~$0 (Firestore free tier) | ~$3-5 (small VPS) | ~$0-10 (depending on DB) |
+| **Credential location** | Client localStorage | Server (Firestore, encrypted) | Server (memory, plaintext) | Server (DB, encrypted) |
+| **GDPR considerations** | Minimal | Moderate | Moderate | Significant |
+
+## Recommendation
+
+**For now: Option 1 as immediate improvement + Option 2 as the next step.**
+
+1. **This week**: Ship Option 1 changes — they're low-risk and improve UX immediately. The `ensureSession()` and `validateSession()` functions are already written; just wire them in with the Visibility API and pre-request guards.
+
+2. **Next iteration**: Implement Option 2 with Firestore. It's the best fit for Cloud Run, removes plaintext credentials from the client, and gives a clear security story. Firestore's free tier means near-zero cost increase.
+
+3. **Longer term**: If fetchBolig.js grows into a multi-user product, evolve toward Option 4. The session store from Option 2 becomes the `linkedAccounts` table, so it's a natural progression rather than a rewrite.
+
+Option 3 (VPS) is a good alternative to Option 2 if you value simplicity over resilience. The main trade-off is losing sessions on deploys and having no horizontal scaling — totally fine for a small user base, but Cloud Run + Firestore is arguably simpler to operate long-term.

--- a/client/public/icons/eye-off.svg
+++ b/client/public/icons/eye-off.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v0.575.0 - ISC -->
+<svg
+  class="lucide lucide-eye-off"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+  <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+  <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+  <path d="m2 2 20 20" />
+</svg>

--- a/client/public/icons/eye.svg
+++ b/client/public/icons/eye.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v0.575.0 - ISC -->
+<svg
+  class="lucide lucide-eye"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+  <circle cx="12" cy="12" r="3" />
+</svg>

--- a/client/src/components/LandingSection.vue
+++ b/client/src/components/LandingSection.vue
@@ -7,6 +7,7 @@ import { useAuth } from "~/composables/useAuth";
 const auth = useAuth();
 const { t } = useI18n();
 const password = ref("");
+const showPassword = ref(false);
 
 async function handleLogin() {
   if (await auth.login(auth.email, password.value)) {
@@ -56,13 +57,24 @@ async function handleLogin() {
             :disabled="auth.isLoading"
             class="disabled:opacity-50 px-3 py-2 border border-violet-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500 bg-white dark:bg-transparent"
           />
-          <input
-            v-model="password"
-            type="password"
-            :placeholder="t('landing.passwordPlaceholder')"
-            :disabled="auth.isLoading"
-            class="disabled:opacity-50 px-3 py-2 border border-violet-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500 bg-white dark:bg-transparent"
-          />
+          <div class="relative">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              :placeholder="t('landing.passwordPlaceholder')"
+              :disabled="auth.isLoading"
+              class="disabled:opacity-50 w-full px-3 py-2 pr-10 border border-violet-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500 bg-white dark:bg-transparent"
+            />
+            <button
+              type="button"
+              @click="showPassword = !showPassword"
+              class="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              tabindex="-1"
+            >
+              <img v-if="showPassword" src="/icons/eye-off.svg" alt="Hide password" class="size-5 dark:invert opacity-60" />
+              <img v-else src="/icons/eye.svg" alt="Show password" class="size-5 dark:invert opacity-60" />
+            </button>
+          </div>
 
           <button
             type="submit"

--- a/client/src/components/LoginForm.vue
+++ b/client/src/components/LoginForm.vue
@@ -7,6 +7,7 @@ import { useAuth } from "~/composables/useAuth";
 const auth = useAuth();
 const { t } = useI18n();
 const password = ref("");
+const showPassword = ref(false);
 const isLogoutModalOpen = ref(false);
 
 async function handleLogin() {
@@ -88,15 +89,24 @@ function confirmLogout() {
               />
             </div>
 
-            <div class="flex flex-col gap-2">
+            <div class="relative flex flex-col gap-2">
               <input
                 id="password"
                 v-model="password"
-                type="password"
+                :type="showPassword ? 'text' : 'password'"
                 :placeholder="t('landing.passwordPlaceholder')"
                 :disabled="auth.isLoading"
-                class="disabled:opacity-50 px-3 py-2 border border-violet-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500 bg-white dark:bg-transparent"
+                class="disabled:opacity-50 px-3 py-2 pr-10 border border-violet-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-violet-500 bg-white dark:bg-transparent"
               />
+              <button
+                type="button"
+                @click="showPassword = !showPassword"
+                class="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                tabindex="-1"
+              >
+                <img v-if="showPassword" src="/icons/eye-off.svg" alt="Hide password" class="size-5 dark:invert opacity-60" />
+                <img v-else src="/icons/eye.svg" alt="Show password" class="size-5 dark:invert opacity-60" />
+              </button>
             </div>
 
             <button

--- a/client/src/composables/useGroupAppointments.ts
+++ b/client/src/composables/useGroupAppointments.ts
@@ -64,6 +64,15 @@ export function useGroupAppointments(appointments: Ref<Appointment[]>, groupBy: 
         break;
     }
 
+    // Sort appointments within each group ascending by date then start time
+    for (const [, items] of groups) {
+      items.sort((a, b) => {
+        const dateComp = (a.date ?? "").localeCompare(b.date ?? "");
+        if (dateComp !== 0) return dateComp;
+        return (a.start ?? "").localeCompare(b.start ?? "");
+      });
+    }
+
     // Sort groups by date, with non-parseable dates last
     return groups.sort(([keyA], [keyB]) => {
       // Check if keys are the special NO_DATE_KEY
@@ -82,8 +91,8 @@ export function useGroupAppointments(appointments: Ref<Appointment[]>, groupBy: 
       if (isValidA && !isValidB) return -1;
       if (!isValidA && !isValidB) return 0;
 
-      // Both valid, sort chronologically (newest first)
-      return dateB.getTime() - dateA.getTime();
+      // Both valid, sort chronologically (soonest first)
+      return dateA.getTime() - dateB.getTime();
     });
   });
 
@@ -95,8 +104,13 @@ export function useGroupAppointments(appointments: Ref<Appointment[]>, groupBy: 
     }
     const loc = unref(locale);
     switch (groupBy.value) {
-      case "day":
+      case "day": {
+        const today = new Date().toISOString().slice(0, 10);
+        const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+        if (key === today) return t("common.today");
+        if (key === tomorrow) return t("common.tomorrow");
         return formatDay(key, loc);
+      }
       case "week":
         return formatWeek(key, loc, t("common.week"));
       case "month":

--- a/client/src/data/appointments.ts
+++ b/client/src/data/appointments.ts
@@ -1,6 +1,7 @@
+import type { CachedAppointmentEntry } from "@/types";
 import { deserializeAppointmentsPayload } from "~/lib/serialization";
 import { useToastStore } from "~/stores/toast";
-import { fetchAppointments } from "./appointmentsSource";
+import { fetchAppointments, syncAppointments } from "./appointmentsSource";
 
 const STORAGE_KEY = "appointments_cache";
 
@@ -22,6 +23,23 @@ export function isCacheStale(thresholdMs = 24 * 60 * 60 * 1000): boolean {
   return age > thresholdMs;
 }
 
+function buildCacheEntries(): CachedAppointmentEntry[] {
+  const cached = localStorage.getItem(STORAGE_KEY);
+  if (!cached) return [];
+  try {
+    const parsed = JSON.parse(cached);
+    const appointments = parsed.appointments ?? [];
+    return appointments.map((appt: any) => ({
+      offerId: appt.offerId ?? appt.id?.replace(/^DEAS-O-/, "") ?? "",
+      messageCount: appt.messageCount ?? 0,
+      date: appt.date ?? null,
+      appointment: appt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function getAppointments(forceRefresh: boolean = false, includeAll: boolean = false) {
   if (!forceRefresh) {
     const cached = localStorage.getItem(STORAGE_KEY);
@@ -36,7 +54,10 @@ export async function getAppointments(forceRefresh: boolean = false, includeAll:
     }
   }
 
-  const payload = await fetchAppointments(includeAll);
+  const cacheEntries = buildCacheEntries();
+  const payload = cacheEntries.length > 0
+    ? await syncAppointments(cacheEntries, includeAll)
+    : await fetchAppointments(includeAll);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   return payload;
 }

--- a/client/src/data/appointmentsSource.ts
+++ b/client/src/data/appointmentsSource.ts
@@ -1,4 +1,4 @@
-import type { Appointment, UserData } from "@/types";
+import type { Appointment, CachedAppointmentEntry, SyncAppointmentsRequest, UserData } from "@/types";
 import mockAppointmentsJson from "~/data/MOCK_APPOINTMENTS.json";
 
 import config from "~/config";
@@ -87,6 +87,31 @@ export async function fetchAppointments(includeAll: boolean = false): Promise<{
     console.error("Failed to fetch appointments:", error);
     throw error;
   }
+}
+
+export async function syncAppointments(
+  cached: CachedAppointmentEntry[],
+  includeAll: boolean = false,
+): Promise<{
+  updatedAt: Date;
+  appointments: Appointment[];
+}> {
+  const body: SyncAppointmentsRequest = { cached, includeAll };
+  const result = await fetchWithTimeout(
+    `${config.backendDomain}/api/appointments/sync`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(body),
+    },
+    TIMEOUT_APPOINTMENTS,
+  );
+  if (!result.ok) {
+    throw new HttpError(`Failed to sync appointments: ${result.status}`, result.status);
+  }
+  const data = await result.json();
+  return { updatedAt: new Date(), appointments: data as Appointment[] };
 }
 
 export async function login(

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -7,7 +7,9 @@
     "backToHome": "Tilbage til forsiden",
     "day": "Dag",
     "week": "Uge",
-    "month": "Måned"
+    "month": "Måned",
+    "today": "I dag",
+    "tomorrow": "I morgen"
   },
   "appointments": {
     "emptyTitle": "Ingen kommende aftaler",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -7,7 +7,9 @@
     "backToHome": "Back to home",
     "day": "Day",
     "week": "Week",
-    "month": "Month"
+    "month": "Month",
+    "today": "Today",
+    "tomorrow": "Tomorrow"
   },
   "appointments": {
     "emptyTitle": "No upcoming appointments",

--- a/client/src/lib/serialization.ts
+++ b/client/src/lib/serialization.ts
@@ -10,6 +10,7 @@ export function deserializeAppointments(data: any[]): Appointment[] {
     // start and end are already strings (HH:mm format)
     // Derive offerId from id if missing (e.g. stale cache from before offerId was added)
     offerId: item.offerId ?? item.id?.replace(/^DEAS-O-/, "") ?? "",
+    messageCount: item.messageCount ?? 0,
   }));
 }
 

--- a/docs/superpowers/plans/2026-04-27-incremental-appointment-sync.md
+++ b/docs/superpowers/plans/2026-04-27-incremental-appointment-sync.md
@@ -1,0 +1,533 @@
+# Incremental Appointment Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the "Sync data" flow faster by having the client send its cached appointments to the server, so the server can skip expensive LLM/API calls for past and unchanged appointments.
+
+**Architecture:** New `POST /api/appointments/sync` endpoint accepts cached appointment metadata from the client. Server categorizes each offer into one of three paths (past → echo cached, unchanged thread → skip LLM, new/changed → full processing). Response shape stays `Appointment[]`.
+
+**Tech Stack:** TypeScript, Hono (server), Vue/Pinia (client), OpenAI API, shared types between client/server.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-incremental-appointment-sync-design.md`
+
+**Note:** This project has no test infrastructure. Tasks focus on implementation with manual verification.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `shared/types.ts` | Modify | Add `messageCount` to `Appointment`, add `CachedAppointmentEntry` and `SyncAppointmentsRequest` types |
+| `server/src/lib/findbolig-domain.ts` | Modify | Accept `messageCount` in `mapAppointmentToDomain` |
+| `server/src/findbolig-service.ts` | Modify | Add 3-path logic to `getUpcomingAppointments`, pass `messageCount` through |
+| `server/src/index.ts` | Modify | Add `POST /api/appointments/sync` endpoint |
+| `client/src/data/appointmentsSource.ts` | Modify | Add `syncAppointments()` function |
+| `client/src/data/appointments.ts` | Modify | Build `CachedAppointmentEntry[]` from localStorage, call `syncAppointments` |
+| `client/src/lib/serialization.ts` | Modify | Default `messageCount` to 0 for old cache entries |
+
+---
+
+## Chunk 1: Shared Types & Server Domain Mapping
+
+### Task 1: Add shared types
+
+**Files:**
+- Modify: `shared/types.ts`
+
+- [ ] **Step 1: Add `messageCount` to `Appointment` type**
+
+In `shared/types.ts`, add `messageCount` as an optional field to the `Appointment` type, after the `declined` field (line 17):
+
+```ts
+  declined: string | null;
+  messageCount?: number;
+};
+```
+
+- [ ] **Step 2: Add `CachedAppointmentEntry` and `SyncAppointmentsRequest` types**
+
+Add these after the existing `Offer` type at the end of `shared/types.ts`:
+
+```ts
+export type CachedAppointmentEntry = {
+  offerId: string;
+  messageCount: number;
+  date: string | null;
+  appointment: Appointment;
+};
+
+export type SyncAppointmentsRequest = {
+  cached: CachedAppointmentEntry[];
+  includeAll: boolean;
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/types.ts
+git commit -m "feat: add messageCount and sync request types to shared types"
+```
+
+---
+
+### Task 2: Update `mapAppointmentToDomain` to include `messageCount`
+
+**Files:**
+- Modify: `server/src/lib/findbolig-domain.ts:6-47`
+
+- [ ] **Step 1: Add `messageCount` to the function parameter and return value**
+
+Update the function signature to accept `messageCount` and include it in the returned object. In `server/src/lib/findbolig-domain.ts`, change the function:
+
+```ts
+export function mapAppointmentToDomain({
+  offer,
+  residence,
+  details,
+  position,
+  messageCount,
+}: {
+  offer: ApiOffer;
+  residence: Residence;
+  details: AppointmentDetails;
+  position: number | null;
+  messageCount: number;
+}): Appointment {
+  const recipient = offer.recipients?.[0];
+  return {
+    id: `DEAS-O-${offer.id}`,
+    offerId: offer.id,
+    title: residence.title,
+    date: details.date || null,
+    start: details.startTime || null,
+    end: details.endTime || null,
+    cancelled: details.cancelled,
+    residence: {
+      adressLine1: residence.addressLine1,
+      adressLine2: residence.addressLine2,
+      location: residence.location,
+    },
+    financials: {
+      monthlyRentIncludingAconto: residence.monthlyRentIncludingAconto,
+      monthlyRentExcludingAconto: residence.monthlyRentExcludingAconto,
+      utilityCosts: residence.aconto,
+      deposit: residence.deposit,
+      prepaidRent: residence.prepaidRent,
+      firstPayment: residence.firstPayment,
+    },
+    imageUrl: residence.images[0] || "",
+    images: residence.images,
+    blueprints: residence.blueprints,
+    position,
+    recipientState: recipient?.state ?? null,
+    accepted: recipient?.accepted ?? null,
+    declined: recipient?.declined ?? null,
+    messageCount,
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/src/lib/findbolig-domain.ts
+git commit -m "feat: include messageCount in mapAppointmentToDomain"
+```
+
+---
+
+## Chunk 2: Server-Side Incremental Sync Logic
+
+### Task 3: Update `getUpcomingAppointments` with 3-path logic
+
+**Files:**
+- Modify: `server/src/findbolig-service.ts:244-305`
+
+- [ ] **Step 1: Import `CachedAppointmentEntry` type**
+
+Add to the imports at the top of `server/src/findbolig-service.ts`:
+
+```ts
+import type { CachedAppointmentEntry } from "@/types";
+```
+
+- [ ] **Step 2: Add `isDateInPast` helper**
+
+Add this helper function above `getUpcomingAppointments`:
+
+```ts
+function isDateInPast(dateStr: string | null): boolean {
+  if (!dateStr) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return dateStr < today;
+}
+```
+
+- [ ] **Step 3: Rewrite `getUpcomingAppointments` to accept and use cached data**
+
+Replace the existing `getUpcomingAppointments` function with:
+
+```ts
+export async function getUpcomingAppointments(
+  cookies: string,
+  includeAll: boolean = false,
+  cached?: CachedAppointmentEntry[],
+) {
+  try {
+    let offers = (await fetchOffers(cookies)).results;
+
+    if (!includeAll) {
+      offers = offers.filter(
+        (offer) => offer.state === "Finished" || offer.state === "Published",
+      );
+    }
+
+    const cacheMap = new Map(
+      (cached ?? []).map((entry) => [entry.offerId, entry]),
+    );
+
+    const currentYear = new Date().getFullYear().toString();
+
+    const results = await Promise.all(
+      offers.map(async (offer) => {
+        if (!offer.residenceId || !offer.id) {
+          return null;
+        }
+
+        const cachedEntry = cacheMap.get(offer.id);
+
+        // Path 1: Past appointment with cached data — echo back as-is
+        if (cachedEntry && isDateInPast(cachedEntry.date)) {
+          return cachedEntry.appointment;
+        }
+
+        // Fetch thread (needed for Path 2 comparison and Path 3 extraction)
+        const [residence, thread, position] = await Promise.all([
+          getResidence(offer.residenceId, cookies),
+          getThreadForOffer(offer.id, cookies),
+          getPositionOnOffer(offer.id, cookies).catch(() => null),
+        ]);
+
+        if (!thread) {
+          return null;
+        }
+
+        // Path 2: Unchanged thread — skip LLM, reuse cached details
+        if (
+          cachedEntry &&
+          thread.messages.length === cachedEntry.messageCount
+        ) {
+          const details = {
+            date: cachedEntry.appointment.date ?? "",
+            startTime: cachedEntry.appointment.start ?? "",
+            endTime: cachedEntry.appointment.end ?? "",
+            cancelled: cachedEntry.appointment.cancelled,
+          };
+          return mapAppointmentToDomain({
+            offer,
+            residence,
+            details,
+            position,
+            messageCount: thread.messages.length,
+          });
+        }
+
+        // Path 3: New or changed — full LLM extraction
+        let details = await extractAppointmentDetailsWithLLM(thread, currentYear);
+
+        if (!details.date && offer.showingText) {
+          const showingDetails = await extractAppointmentDetailsFromShowingText(
+            offer.showingText,
+            currentYear,
+          );
+          if (showingDetails.date && (showingDetails.startTime || showingDetails.endTime)) {
+            details = showingDetails;
+          }
+        }
+
+        return mapAppointmentToDomain({
+          offer,
+          residence,
+          details,
+          position,
+          messageCount: thread.messages.length,
+        });
+      }),
+    );
+
+    return results.filter(
+      (a): a is NonNullable<typeof a> => a !== null,
+    );
+  } catch (error) {
+    console.error("Failed to fetch upcoming appointments:", error);
+    throw error;
+  }
+}
+```
+
+- [ ] **Step 4: Verify the server compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No type errors (or only pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/findbolig-service.ts
+git commit -m "feat: add 3-path incremental sync logic to getUpcomingAppointments"
+```
+
+---
+
+### Task 4: Add `POST /api/appointments/sync` endpoint
+
+**Files:**
+- Modify: `server/src/index.ts:143-153`
+
+- [ ] **Step 1: Import the sync request type**
+
+Add to the imports at the top of `server/src/index.ts`:
+
+```ts
+import type { SyncAppointmentsRequest } from "@/types";
+```
+
+- [ ] **Step 2: Add the POST sync endpoint**
+
+Add this right after the existing `appointments.get("/upcoming", ...)` block (after line 153):
+
+```ts
+appointments.post("/sync", async (c) => {
+  try {
+    const body = await c.req.json<SyncAppointmentsRequest>();
+    const cached = Array.isArray(body?.cached) ? body.cached : [];
+    const includeAll = body?.includeAll === true;
+    const result = await withReauth(c, (cookies) =>
+      findboligService.getUpcomingAppointments(cookies, includeAll, cached)
+    );
+    return c.json(result);
+  } catch (error) {
+    return handleError(c, error);
+  }
+});
+```
+
+- [ ] **Step 3: Verify the server compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: No type errors (or only pre-existing ones).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/index.ts
+git commit -m "feat: add POST /api/appointments/sync endpoint"
+```
+
+---
+
+## Chunk 3: Client-Side Changes
+
+### Task 5: Update serialization to handle `messageCount`
+
+**Files:**
+- Modify: `client/src/lib/serialization.ts:6-14`
+
+- [ ] **Step 1: Default `messageCount` to 0 for old cache entries**
+
+Update the `deserializeAppointments` function to include `messageCount` defaulting:
+
+```ts
+export function deserializeAppointments(data: any[]): Appointment[] {
+  return data.map((item) => ({
+    ...item,
+    offerId: item.offerId ?? item.id?.replace(/^DEAS-O-/, "") ?? "",
+    messageCount: item.messageCount ?? 0,
+  }));
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/src/lib/serialization.ts
+git commit -m "feat: default messageCount to 0 in deserialization"
+```
+
+---
+
+### Task 6: Add `syncAppointments` client function
+
+**Files:**
+- Modify: `client/src/data/appointmentsSource.ts:58-90`
+
+- [ ] **Step 1: Import the sync request type**
+
+Add to the imports at the top of `client/src/data/appointmentsSource.ts`:
+
+```ts
+import type { CachedAppointmentEntry, SyncAppointmentsRequest } from "@/types";
+```
+
+- [ ] **Step 2: Add `syncAppointments` function**
+
+Add this after the existing `fetchAppointments` function (after line 90):
+
+```ts
+export async function syncAppointments(
+  cached: CachedAppointmentEntry[],
+  includeAll: boolean = false,
+): Promise<{
+  updatedAt: Date;
+  appointments: Appointment[];
+}> {
+  const body: SyncAppointmentsRequest = { cached, includeAll };
+  const result = await fetchWithTimeout(
+    `${config.backendDomain}/api/appointments/sync`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(body),
+    },
+    TIMEOUT_APPOINTMENTS,
+  );
+  if (!result.ok) {
+    throw new HttpError(`Failed to sync appointments: ${result.status}`, result.status);
+  }
+  const data = await result.json();
+  return { updatedAt: new Date(), appointments: data as Appointment[] };
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/data/appointmentsSource.ts
+git commit -m "feat: add syncAppointments client function"
+```
+
+---
+
+### Task 7: Wire up cache-aware sync in the data layer
+
+**Files:**
+- Modify: `client/src/data/appointments.ts`
+
+- [ ] **Step 1: Update imports**
+
+Replace the import from `appointmentsSource` to also include `syncAppointments`:
+
+```ts
+import { fetchAppointments, syncAppointments } from "./appointmentsSource";
+```
+
+Also add the type import:
+
+```ts
+import type { CachedAppointmentEntry } from "@/types";
+```
+
+- [ ] **Step 2: Add helper to build cache entries from localStorage**
+
+Add this function before `getAppointments`:
+
+```ts
+function buildCacheEntries(): CachedAppointmentEntry[] {
+  const cached = localStorage.getItem(STORAGE_KEY);
+  if (!cached) return [];
+  try {
+    const parsed = JSON.parse(cached);
+    const appointments = parsed.appointments ?? [];
+    return appointments.map((appt: any) => ({
+      offerId: appt.offerId ?? appt.id?.replace(/^DEAS-O-/, "") ?? "",
+      messageCount: appt.messageCount ?? 0,
+      date: appt.date ?? null,
+      appointment: appt,
+    }));
+  } catch {
+    return [];
+  }
+}
+```
+
+- [ ] **Step 3: Update `getAppointments` to use `syncAppointments`**
+
+Replace the existing `getAppointments` function:
+
+```ts
+export async function getAppointments(forceRefresh: boolean = false, includeAll: boolean = false) {
+  if (!forceRefresh) {
+    const cached = localStorage.getItem(STORAGE_KEY);
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached);
+        return deserializeAppointmentsPayload(parsed);
+      } catch (error) {
+        const toast = useToastStore();
+        toast.warning("Failed to load cached data, fetching fresh data...");
+      }
+    }
+  }
+
+  const cacheEntries = buildCacheEntries();
+  const payload = cacheEntries.length > 0
+    ? await syncAppointments(cacheEntries, includeAll)
+    : await fetchAppointments(includeAll);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  return payload;
+}
+```
+
+- [ ] **Step 4: Verify the client compiles**
+
+Run: `cd client && npx vue-tsc --noEmit`
+Expected: No type errors (or only pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/data/appointments.ts
+git commit -m "feat: wire up cache-aware incremental sync in data layer"
+```
+
+---
+
+## Chunk 4: Manual Verification
+
+### Task 8: End-to-end verification
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `cd server && npm run dev` (in one terminal)
+Run: `cd client && npm run dev` (in another terminal)
+
+- [ ] **Step 2: Test first sync (empty cache)**
+
+1. Clear localStorage in the browser (DevTools → Application → Local Storage → Clear)
+2. Click "Sync data"
+3. Verify: appointments load (full processing, same as before)
+4. Verify: `appointments_cache` in localStorage now contains entries with `messageCount` fields
+
+- [ ] **Step 3: Test second sync (cache populated)**
+
+1. Click "Sync data" again without clearing cache
+2. Verify: the sync is noticeably faster (server skips LLM for unchanged threads)
+3. Verify: results are identical to first sync
+4. Check server logs: should see fewer OpenAI API calls
+
+- [ ] **Step 4: Test past appointment handling**
+
+1. If any appointments have dates in the past, verify they still appear in the list
+2. Verify server logs show those offers were skipped entirely (no API calls)
+
+- [ ] **Step 5: Test mock data path still works**
+
+1. If `useMockData` config exists, toggle it on
+2. Verify mock data still loads correctly (uses `fetchAppointments`, not `syncAppointments`)
+
+- [ ] **Step 6: Final commit with any fixes**
+
+If any issues found during testing, fix and commit.

--- a/docs/superpowers/specs/2026-04-27-incremental-appointment-sync-design.md
+++ b/docs/superpowers/specs/2026-04-27-incremental-appointment-sync-design.md
@@ -1,0 +1,124 @@
+# Incremental Appointment Sync
+
+## Problem
+
+The "Sync data" flow for appointments is slow. Each sync fetches all offers from findbolig.nu, loads residence/thread/position data for each one, and runs OpenAI extraction on every thread. With 15-20 offers this means 60-100 HTTP requests including 15-20+ LLM calls, taking 30-60+ seconds. None of the server-side work is cached, and the server (Cloud Run) is stateless with no persistent storage.
+
+## Solution
+
+Client-aware incremental sync. The client already caches appointments in localStorage. On sync, it sends its cached data back to the server so the server can skip expensive work for unchanged or past appointments.
+
+## Design Decisions
+
+- **Message count as change detector:** findbolig.nu threads are append-only (messages are never edited, new messages are sent instead). Comparing `thread.messages.length` against the cached `messageCount` is sufficient to detect changes.
+- **Past appointments: skip all processing, echo cached data.** Past appointments are still returned (stay visible in UI) but no API calls or LLM extraction is done for them.
+- **Same response shape:** The server still returns `Appointment[]`. The client doesn't need new merge/diff logic.
+- **Graceful degradation:** Empty cache (first load, cleared storage) results in full processing, identical to current behavior.
+- **No extra infrastructure:** No Redis, Firestore, or persistent storage needed. The client's localStorage is the cache.
+
+## Shared Types
+
+Add to `shared/types.ts`:
+
+```ts
+export type CachedAppointmentEntry = {
+  offerId: string;
+  messageCount: number;
+  date: string | null;
+  appointment: Appointment;
+};
+
+export type SyncAppointmentsRequest = {
+  cached: CachedAppointmentEntry[];
+  includeAll: boolean;
+};
+```
+
+Add `messageCount?: number` (optional) field to the existing `Appointment` type. This is populated by the server from `thread.messages.length` and flows through to the client cache. It is optional so that old cached data (which lacks the field) remains valid TypeScript. The deserialization layer defaults missing values to 0, which causes a mismatch on next sync and triggers full reprocessing (self-healing).
+
+## Server Changes
+
+### New endpoint: `POST /api/appointments/sync`
+
+Replaces `GET /api/appointments/upcoming` as the primary sync endpoint. The GET endpoint remains for backward compatibility.
+
+**Request body:** `SyncAppointmentsRequest`
+**Response:** `Appointment[]`
+
+### Processing logic in `getUpcomingAppointments`
+
+Accept an optional `cached` parameter (a Map of `offerId -> CachedAppointmentEntry`).
+
+For each offer, the server follows one of three paths:
+
+| # | Condition | Action | Calls saved |
+|---|-----------|--------|-------------|
+| # | Condition | Action | Calls saved |
+|---|-----------|--------|-------------|
+| 1 | Offer has a cached entry with a non-null `date` that is before today | Echo back `cachedEntry.appointment` directly | All: 3 API + 1-2 LLM |
+| 2 | Offer has a cached entry; thread fetched and `thread.messages.length === cachedEntry.messageCount` | Fetch residence + position (for live financial/position data), but skip all LLM extraction and reuse cached date/time/cancelled details | 1-2 LLM calls |
+| 3 | No cache entry, or thread message count changed, new offer, or cached `date` is `null` | Full processing (current behavior) | None |
+
+**Path 1** skips everything (no residence, thread, or position fetch). The appointment data is frozen. Only applies when `date` is a non-null string that parses to a date strictly before today. If `date` is `null` (LLM couldn't extract a date), the appointment is NOT treated as past — it falls to Path 2 or 3.
+
+**Path 2** still fetches the thread (to compare message count), residence (for live financial/image data), and position (queue number changes frequently). It skips **both** LLM extraction calls — the thread-based extraction (`extractAppointmentDetailsWithLLM`) AND the `showingText` fallback (`extractAppointmentDetailsFromShowingText`). The `AppointmentDetails` (date, startTime, endTime, cancelled) are taken from the cached appointment.
+
+**Path 3** is the existing behavior, unchanged.
+
+### Domain mapping
+
+`mapAppointmentToDomain` in `findbolig-domain.ts` currently accepts `{ offer, residence, details, position }`. Add `messageCount` to this parameter object so the function can include it in the returned `Appointment`. The value comes from `thread.messages.length`.
+
+### GET endpoint
+
+The existing `GET /api/appointments/upcoming` remains and calls `getUpcomingAppointments` with no `cached` parameter, triggering full processing for all offers. No implementation changes needed for the GET endpoint.
+
+### Validation
+
+The server should tolerate malformed or unexpected `cached` entries gracefully. If a `CachedAppointmentEntry` references an `offerId` not in the current offers list, it is simply ignored. If the `cached` array is missing or invalid, fall back to full processing.
+
+### `includeAll` interaction
+
+The `includeAll` filter is applied to the fresh offers list before cache lookups. Only offers that pass the filter are processed. Cached entries for offers that don't pass the filter are ignored.
+
+## Client Changes
+
+### `shared/types.ts`
+- Add `messageCount?: number` (optional) to `Appointment` type
+- Add `CachedAppointmentEntry` and `SyncAppointmentsRequest` types
+
+### `client/src/data/appointmentsSource.ts`
+- New function `syncAppointments(cached: CachedAppointmentEntry[], includeAll: boolean)` that sends `POST /api/appointments/sync`
+- Keeps existing `fetchAppointments` for backward compatibility / mock data path
+
+### `client/src/data/appointments.ts`
+- `getAppointments(forceRefresh, includeAll)` builds `CachedAppointmentEntry[]` from the localStorage cache and calls `syncAppointments` instead of `fetchAppointments`
+- If cache is empty or invalid, sends `cached: []` (triggers full processing)
+
+### `client/src/stores/appointments.ts`
+- Minimal changes. The store calls `getAppointments` as before; the data layer handles cache-aware sync internally.
+
+### `client/src/lib/serialization.ts`
+- Handle `messageCount` in deserialization (default to 0 for old cached data without the field)
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| First sync / empty cache | `cached: []` sent, server does full processing for all offers |
+| Offer removed upstream | Server fetches current offers list; removed offers are not in the response and disappear from the client |
+| Offer state changes (accepted/declined) | Path 1 (past): echoed as-is (state changes don't matter for past). Path 2 (unchanged thread): offer state is fetched fresh from the offers list and applied |
+| Thread goes from 0 to 1+ messages | `messageCount` mismatch (0 vs N) triggers Path 3, full processing |
+| Old cached data without `messageCount` | Deserialization defaults to 0, which will mismatch against any thread with messages, triggering full reprocessing (self-healing) |
+
+## Performance Impact
+
+Assuming 15 offers where 5 are past, 8 are unchanged, and 2 have new messages:
+
+| | Before | After |
+|---|--------|-------|
+| findbolig API calls | 46 (1 offers list + 15x3 per-offer) | 31 (1 offers list + 8x3 unchanged + 2x3 new, 5 past skipped entirely) |
+| OpenAI LLM calls | 15-30 | 2-4 (only new/changed offers) |
+| Estimated time | 30-60s | 5-15s |
+
+The biggest win is eliminating LLM calls for unchanged and past offers.

--- a/server/src/findbolig-service.ts
+++ b/server/src/findbolig-service.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 
+import type { CachedAppointmentEntry } from "@/types";
 import { UserData } from "@/types";
 import { apiResidenceToDomain, apiUserDataToDomain, mapAppointmentToDomain, mapOfferToDomain } from "~/lib/findbolig-domain";
 import type { ApiOffer, ApiOffersPage, ApiUserData } from "~/types/offers";
@@ -236,19 +237,25 @@ export async function getThreadForOffer(
   return JSON.parse(text) as ApiMessageThreadFull;
 }
 
+function isDateInPast(dateStr: string | null): boolean {
+  if (!dateStr) return false;
+  const today = new Date().toISOString().slice(0, 10);
+  return dateStr < today;
+}
+
 /**
- * Fetches upcoming appointments
+ * Fetches upcoming appointments with optional incremental sync.
+ * When `cached` is provided, the server skips expensive work for past and unchanged appointments.
  * @param includeAll - If true, fetches all offers; if false, only fetches active offers (Finished/Published)
- * @returns
+ * @param cached - Optional cached appointment entries from the client for incremental sync
  */
 export async function getUpcomingAppointments(
   cookies: string,
   includeAll: boolean = false,
+  cached?: CachedAppointmentEntry[],
 ) {
   try {
     let offers = (await fetchOffers(cookies)).results;
-    // So far it seems that the default state once you get the offer is either 'Finished' or 'Published'
-    // there may be other state values used that represents same state
 
     if (!includeAll) {
       offers = offers.filter(
@@ -256,46 +263,80 @@ export async function getUpcomingAppointments(
       );
     }
 
+    const cacheMap = new Map(
+      (cached ?? []).map((entry) => [entry.offerId, entry]),
+    );
+
     const currentYear = new Date().getFullYear().toString();
 
-    const offersWithResidenceAndThread = await Promise.all(
+    const results = await Promise.all(
       offers.map(async (offer) => {
         if (!offer.residenceId || !offer.id) {
           return null;
         }
+
+        const cachedEntry = cacheMap.get(offer.id);
+
+        // Path 1: Past appointment with cached data — echo back as-is
+        if (cachedEntry && isDateInPast(cachedEntry.date)) {
+          return cachedEntry.appointment;
+        }
+
+        // Fetch thread (needed for Path 2 comparison and Path 3 extraction)
         const [residence, thread, position] = await Promise.all([
           getResidence(offer.residenceId, cookies),
           getThreadForOffer(offer.id, cookies),
           getPositionOnOffer(offer.id, cookies).catch(() => null),
         ]);
+
         if (!thread) {
           return null;
         }
+
+        // Path 2: Unchanged thread — skip LLM, reuse cached details
+        if (
+          cachedEntry &&
+          thread.messages.length === cachedEntry.messageCount
+        ) {
+          const details = {
+            date: cachedEntry.appointment.date ?? "",
+            startTime: cachedEntry.appointment.start ?? "",
+            endTime: cachedEntry.appointment.end ?? "",
+            cancelled: cachedEntry.appointment.cancelled,
+          };
+          return mapAppointmentToDomain({
+            offer,
+            residence,
+            details,
+            position,
+            messageCount: thread.messages.length,
+          });
+        }
+
+        // Path 3: New or changed — full LLM extraction
         let details = await extractAppointmentDetailsWithLLM(thread, currentYear);
 
-        // Fallback: if no date from thread messages, try the offer's showingText
         if (!details.date && offer.showingText) {
           const showingDetails = await extractAppointmentDetailsFromShowingText(
             offer.showingText,
             currentYear,
           );
-          // Only use showing text details if we got a date WITH times
-          // (a date without times likely means the LLM picked up a deadline/move-in date)
           if (showingDetails.date && (showingDetails.startTime || showingDetails.endTime)) {
             details = showingDetails;
           }
         }
-        const domainAppointment = mapAppointmentToDomain({
+
+        return mapAppointmentToDomain({
           offer,
           residence,
           details,
           position,
+          messageCount: thread.messages.length,
         });
-        return domainAppointment;
       }),
     );
 
-    return offersWithResidenceAndThread.filter(
+    return results.filter(
       (a): a is NonNullable<typeof a> => a !== null,
     );
   } catch (error) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { prettyJSON } from "hono/pretty-json";
 import * as findboligService from "~/findbolig-service";
+import type { SyncAppointmentsRequest } from "@/types";
 import { TimeoutError } from "~/findbolig-service";
 import { AuthError, withReauth } from "~/lib/auth-helpers";
 import {
@@ -145,6 +146,20 @@ appointments.get("/upcoming", async (c) => {
     const includeAll = c.req.query("includeAll") === "true";
     const result = await withReauth(c, (cookies) =>
       findboligService.getUpcomingAppointments(cookies, includeAll)
+    );
+    return c.json(result);
+  } catch (error) {
+    return handleError(c, error);
+  }
+});
+
+appointments.post("/sync", async (c) => {
+  try {
+    const body = await c.req.json<SyncAppointmentsRequest>();
+    const cached = Array.isArray(body?.cached) ? body.cached : [];
+    const includeAll = body?.includeAll === true;
+    const result = await withReauth(c, (cookies) =>
+      findboligService.getUpcomingAppointments(cookies, includeAll, cached)
     );
     return c.json(result);
   } catch (error) {

--- a/server/src/lib/findbolig-domain.ts
+++ b/server/src/lib/findbolig-domain.ts
@@ -8,11 +8,13 @@ export function mapAppointmentToDomain({
   residence,
   details,
   position,
+  messageCount,
 }: {
   offer: ApiOffer;
   residence: Residence;
   details: AppointmentDetails;
   position: number | null;
+  messageCount: number;
 }): Appointment {
   const recipient = offer.recipients?.[0];
   return {
@@ -43,6 +45,7 @@ export function mapAppointmentToDomain({
     recipientState: recipient?.state ?? null,
     accepted: recipient?.accepted ?? null,
     declined: recipient?.declined ?? null,
+    messageCount,
   };
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -15,6 +15,7 @@ export type Appointment = {
   recipientState: string | null;
   accepted: string | null;
   declined: string | null;
+  messageCount?: number;
 };
 
 export type Financials = {
@@ -53,4 +54,16 @@ export type Offer = {
   images: string[];
   blueprints: string[];
   position: number | null;
+};
+
+export type CachedAppointmentEntry = {
+  offerId: string;
+  messageCount: number;
+  date: string | null;
+  appointment: Appointment;
+};
+
+export type SyncAppointmentsRequest = {
+  cached: CachedAppointmentEntry[];
+  includeAll: boolean;
 };


### PR DESCRIPTION
## Summary
- **Password toggle & appointment sorting:** UI improvements from a previous session (show/hide password, ascending sort, today/tomorrow labels)
- **Incremental sync design spec:** Design for making appointment sync much faster by having the client send its cached data to the server, so the server can skip expensive OpenAI LLM calls and findbolig.nu API calls for unchanged/past appointments

## Design highlights
- New `POST /api/appointments/sync` endpoint that accepts cached appointment data
- Three processing paths: past (skip everything), unchanged thread (skip LLM), new/changed (full processing)
- No extra infrastructure needed — client's localStorage is the cache
- Estimated improvement: 15-30 LLM calls → 2-4, 46 API calls → 31, ~30-60s → ~5-15s

## Test plan
- [ ] Verify existing UI changes (password toggle, sorting) work correctly
- [ ] Review design spec at `docs/superpowers/specs/2026-04-27-incremental-appointment-sync-design.md`
- [ ] Implementation to follow in subsequent commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)